### PR TITLE
Fix Uncaught LocaleDataException

### DIFF
--- a/lib/aliyun_oss_flutter.dart
+++ b/lib/aliyun_oss_flutter.dart
@@ -4,9 +4,10 @@ import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
 
-import 'package:image/image.dart' as img;
+// import 'package:image/image.dart' as img;
 import 'package:crypto/crypto.dart';
 import 'package:intl/intl.dart';
+import 'package:intl/date_symbol_data_local.dart';
 import 'package:path/path.dart' as path;
 import 'package:dio/dio.dart';
 import 'package:http_parser/http_parser.dart';

--- a/lib/src/signer.dart
+++ b/lib/src/signer.dart
@@ -99,6 +99,7 @@ class Signer {
   }
 
   String _requestTime() {
+    initializeDateFormatting('en', null);
     final DateTime now = DateTime.now();
     final String string =
         DateFormat('EEE, dd MMM yyyy HH:mm:ss', 'en_ISO').format(now.toUtc());


### PR DESCRIPTION
在MaterialApp中未配置 `localizationsDelegates` 会复现这个错误

```shell
E/flutter (27515): [ERROR:flutter/lib/ui/ui_dart_state.cc(199)] Unhandled Exception: LocaleDataException: Locale data has not been initialized, call initializeDateFormatting(<locale>).
E/flutter (27515): #0      UninitializedLocaleData._throwException
package:intl/src/intl_helpers.dart:80
E/flutter (27515): #1      UninitializedLocaleData.containsKey
package:intl/src/intl_helpers.dart:74
E/flutter (27515): #2      DateFormat.localeExists
package:intl/…/intl/date_format.dart:834
E/flutter (27515): #3      verifiedLocale
package:intl/src/intl_helpers.dart:159
E/flutter (27515): #4      new DateFormat
package:intl/…/intl/date_format.dart:266
E/flutter (27515): #5      Signer._requestTime
package:aliyun_oss_flutter/src/signer.dart:104
E/flutter (27515): #6      Signer.sign
package:aliyun_oss_flutter/src/signer.dart:60
E/flutter (27515): #7      OSSClient.putObject
package:aliyun_oss_flutter/src/client.dart:52
E/flutter (27515): <asynchronous suspension>
```

可以选择在MaterialApp中配置该内容
```dart
MaterialApp(
  title: 'Flutter Demo',
  home: MyHomePage(),
  localizationsDelegates: const [GlobalMaterialLocalizations.delegate],
)
```

